### PR TITLE
chore: update debezium-server version to 1.7.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <version.awssdk>2.16.88</version.awssdk>
         <version.parquet>1.11.1</version.parquet>
         <!-- Debezium -->
-        <version.debezium>1.7.0.CR1</version.debezium>
+        <version.debezium>1.7.0.Final</version.debezium>
         <version.mysql.driver>8.0.26</version.mysql.driver>
         <!-- Quarkus -->
         <version.quarkus>2.0.3.Final</version.quarkus>


### PR DESCRIPTION
As debezium-server 1.7.0 final has been released, we should use the final version instead of the
RC
