### PR TITLE
refactor: move get or create table behavior to IcebergTableOperations

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergTableOperations.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergTableOperations.java
@@ -1,0 +1,33 @@
+package io.debezium.server.iceberg;
+
+import java.util.Optional;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Wrapper to perform operations in iceberg tables
+ * @author Rafael Acevedo
+ */
+public class IcebergTableOperations {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IcebergTableOperations.class);
+
+  private final Catalog catalog;
+
+  public IcebergTableOperations(Catalog catalog) {
+    this.catalog = catalog;
+  }
+
+  public Optional<Table> loadTable(TableIdentifier tableId) {
+    try {
+      Table table = catalog.loadTable(tableId);
+      return Optional.of(table);
+    } catch (NoSuchTableException e) {
+      LOGGER.warn("table not found: {}", tableId.toString());
+      return Optional.empty();
+    }
+  }
+}


### PR DESCRIPTION
The code related to iceberg table "get or create" behavior was
a bit confusing, with some try catches.

This attemps to make it simpler by moving the `loadTable` operation to
IcebergTableOperations and making it return a `Optional<Table>`. To make
us able to use functional-style code, some `Exception` instances were changed to
`RuntimeException`.
