### PR TITLE
fix: use correct path inside dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn clean package -Passembly -Dmaven.test.skip --quiet
 RUN unzip /app/debezium-server-iceberg-dist/target/debezium-server-iceberg-dist*.zip -d appdist
 
 FROM eclipse-temurin:11-jre
-COPY --from=builder /app/appdist/ /app/
+COPY --from=builder /app/appdist/debezium-server-iceberg/ /app/
 
 WORKDIR /app
 EXPOSE 8080 8083


### PR DESCRIPTION
Currently, when we run the docker image, we get:
```
▶ docker run ghcr.io/memiiso/debezium-server-iceberg:latest
docker: Error response from daemon: OCI runtime create failed:
container_linux.go:380: starting container process caused: exec:
"/app/run.sh": stat /app/run.sh: no such file or directory: unknown.
ERRO[0000] error waiting for container: context canceled
```

That's because the appdist folder contains a inner folder and the docker
image does not account for it.

This copies only the `debezium-server-iceberg` folder from the builder
image, containing the expected file tree
