### PR TITLE
Update dist include oracle and db2 connectors

### DIFF
--- a/debezium-server-iceberg-dist/pom.xml
+++ b/debezium-server-iceberg-dist/pom.xml
@@ -91,6 +91,14 @@
                 </dependency>
                 <dependency>
                     <groupId>io.debezium</groupId>
+                    <artifactId>debezium-connector-oracle</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.debezium</groupId>
+                    <artifactId>debezium-connector-db2</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.debezium</groupId>
                     <artifactId>debezium-server-core</artifactId>
                 </dependency>
 <!--                <dependency>-->

--- a/debezium-server-iceberg-dist/pom.xml
+++ b/debezium-server-iceberg-dist/pom.xml
@@ -87,23 +87,47 @@
                 </dependency>
                 <dependency>
                     <groupId>io.debezium</groupId>
+                    <artifactId>debezium-connector-oracle</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.debezium</groupId>
                     <artifactId>debezium-server-core</artifactId>
                 </dependency>
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-kinesis</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-pubsub</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-pulsar</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-eventhubs</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-redis</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-kafka</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-pravega</artifactId>-->
+<!--                </dependency>-->
+<!--                <dependency>-->
+<!--                    <groupId>io.debezium</groupId>-->
+<!--                    <artifactId>debezium-server-nats-streaming</artifactId>-->
+<!--                </dependency>-->
                 <dependency>
-                    <groupId>io.debezium</groupId>
-                    <artifactId>debezium-server-kinesis</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>io.debezium</groupId>
-                    <artifactId>debezium-server-pubsub</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>io.debezium</groupId>
-                    <artifactId>debezium-server-pulsar</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>io.debezium</groupId>
-                    <artifactId>debezium-server-eventhubs</artifactId>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-logging-json</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>io.debezium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <version.awssdk>2.16.88</version.awssdk>
         <version.parquet>1.11.1</version.parquet>
         <!-- Debezium -->
-        <version.debezium>1.7.0.Final</version.debezium>
+        <version.debezium>1.7.1.Final</version.debezium>
         <version.mysql.driver>8.0.26</version.mysql.driver>
         <!-- Quarkus -->
         <version.quarkus>2.2.3.Final</version.quarkus>


### PR DESCRIPTION
Update dist include oracle and db2 connectors
disable other sinks only package `debezium-server-iceberg-sink`
upgrade debezium to 1.7.1.Final