### PR TITLE
Remove usages of ObjectNode.put(String, JsonNode) as it is deprecated

### DIFF
--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/testresources/IcebergChangeEventBuilder.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/testresources/IcebergChangeEventBuilder.java
@@ -44,14 +44,14 @@ public class IcebergChangeEventBuilder {
   public IcebergChangeEventBuilder addField(String parentFieldName, String name, String val) {
     ObjectNode nestedField = JsonNodeFactory.instance.objectNode();
     nestedField.put(name, val);
-    this.payload.put(parentFieldName, nestedField);
+    this.payload.set(parentFieldName, nestedField);
     return this;
   }
 
   public IcebergChangeEventBuilder addField(String parentFieldName, String name, int val) {
     ObjectNode nestedField = JsonNodeFactory.instance.objectNode();
     nestedField.put(name, val);
-    this.payload.put(parentFieldName, nestedField);
+    this.payload.set(parentFieldName, nestedField);
     return this;
   }
 
@@ -62,7 +62,7 @@ public class IcebergChangeEventBuilder {
       nestedField = (ObjectNode) this.payload.get(parentFieldName);
     }
     nestedField.put(name, val);
-    this.payload.put(parentFieldName, nestedField);
+    this.payload.set(parentFieldName, nestedField);
     return this;
   }
 


### PR DESCRIPTION
It is replaced by `set(String, JsonNode)`. Ref:
https://github.com/FasterXML/jackson-databind/blob/2.14/src/main/java/com/fasterxml/jackson/databind/node/ObjectNode.java#L644
