### PR TITLE
Remove outdated/unused config

### DIFF
--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/batchsizewait/MaxBatchSizeWaitTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/batchsizewait/MaxBatchSizeWaitTest.java
@@ -69,8 +69,6 @@ class MaxBatchSizeWaitTest extends BaseSparkTest {
       Map<String, String> config = new HashMap<>();
       // wait
       config.put("debezium.sink.batch.batch-size-wait", "MaxBatchSizeWait");
-      config.put("debezium.sink.batch.metrics.snapshot-mbean", "debezium.postgres:type=connector-metrics,context=snapshot,server=testc");
-      config.put("debezium.sink.batch.metrics.streaming-mbean", "debezium.postgres:type=connector-metrics,context=streaming,server=testc");
       config.put("debezium.source.connector.class", "io.debezium.connector.postgresql.PostgresConnector");
       config.put("debezium.source.max.batch.size", "5000");
       config.put("debezium.source.max.queue.size", "70000");

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -84,11 +84,9 @@ MaxBatchSizeWait uses debezium metrics to optimize batch size.
 MaxBatchSizeWait periodically reads streaming queue current size and waits until it reaches to `max.batch.size`. 
 Maximum wait and check intervals are controlled by `debezium.sink.batch.batch-size-wait.max-wait-ms`, `debezium.sink.batch.batch-size-wait.wait-interval-ms` properties.
 
-example setup to receive ~2048 events per commit. maximum wait is set to 30 seconds, streaming queue current size checked every 5 seconds
+example setup to receive 2048 events per commit. maximum wait is set to 30 seconds, streaming queue current size checked every 5 seconds
 ```properties
 debezium.sink.batch.batch-size-wait=MaxBatchSizeWait
-debezium.sink.batch.metrics.snapshot-mbean=debezium.postgres:type=connector-metrics,context=snapshot,server=testc
-debezium.sink.batch.metrics.streaming-mbean=debezium.postgres:type=connector-metrics,context=streaming,server=testc
 debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
 debezium.source.max.batch.size=2048;
 debezium.source.max.queue.size=16000";


### PR DESCRIPTION
remove/clean outdated configs 

```
debezium.sink.batch.metrics.snapshot-mbean=xxx
debezium.sink.batch.metrics.streaming-mbean=xxx
```