### PR TITLE
documentation typo fix

### DIFF
--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -94,8 +94,8 @@ every 5 seconds
 ```properties
 debezium.sink.batch.batch-size-wait=MaxBatchSizeWait
 debezium.source.connector.class=io.debezium.connector.postgresql.PostgresConnector
-debezium.source.max.batch.size=2048;
-debezium.source.max.queue.size=16000";
+debezium.source.max.batch.size=2048
+debezium.source.max.queue.size=16000
 debezium.sink.batch.batch-size-wait.max-wait-ms=30000
 debezium.sink.batch.batch-size-wait.wait-interval-ms=5000
 ```


### PR DESCRIPTION
"debezium.source.max.batch.size" and "debezium.source.max.queue.size" expect integer values, hence, removed the typos from the doc file.