### PR TITLE
Align package dependencies to iceberg and revert iceberg back to 1.4.3

### DIFF
--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -95,10 +95,12 @@
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
+            <version>${version.googlebigdataoss}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcsio</artifactId>
+            <version>${version.googlebigdataoss}</version>
         </dependency>
         <!-- AWS  -->
         <dependency>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -50,7 +50,7 @@
         <!-- Iceberg  -->
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-spark-runtime-3.3_2.13</artifactId>
+            <artifactId>iceberg-spark-runtime-${version.spark.major}_${version.spark.scala}</artifactId>
             <version>${version.iceberg}</version>
         </dependency>
         <dependency>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -144,6 +144,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- aws-java-sdk-bundle Test dependency -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-bundle</artifactId>
+            <version>1.11.1026</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Hadoop -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -87,22 +87,18 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-nio</artifactId>
-            <version>0.127.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
-            <version>hadoop3-2.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcsio</artifactId>
-            <version>2.2.16</version>
         </dependency>
         <!-- AWS  -->
         <dependency>
@@ -145,12 +141,6 @@
                     <artifactId>aws-java-sdk-bundle</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-bundle</artifactId>
-            <version>1.11.1026</version>
-            <scope>test</scope>
         </dependency>
         <!-- Hadoop -->
         <dependency>
@@ -203,7 +193,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.13</artifactId>
+            <artifactId>spark-core_${version.spark.scala}</artifactId>
             <version>${version.spark}</version>
             <scope>test</scope>
             <exclusions>
@@ -227,7 +217,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.13</artifactId>
+            <artifactId>spark-sql_${version.spark.scala}</artifactId>
             <version>${version.spark}</version>
             <scope>test</scope>
         </dependency>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>
             <artifactId>gcs-connector</artifactId>
-            <version>${version.googlebigdataoss}</version>
+            <version>hadoop3-${version.googlebigdataoss}</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud.bigdataoss</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
         <version.spark>3.4.2</version.spark>
         <version.hadoop>3.3.6</version.hadoop>
         <version.hive>3.1.3</version.hive>
-        <version.awssdk>2.22.9</version.awssdk>
+        <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L31-->  
+        <version.awssdk>2.24.5</version.awssdk>
         <version.testcontainers>1.19.3</version.testcontainers>
         <!-- Debezium -->
         <version.debezium>2.5.2.Final</version.debezium>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,9 @@
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L53-->
         <version.jackson>2.14.2</version.jackson>
         <version.iceberg>1.5.0</version.iceberg>
-        <version.spark>3.4.2</version.spark>
+        <version.spark.major>3.4</version.spark.major>
+        <version.spark.scala>2.13</version.spark.scala>
+        <version.spark>${version.spark.major}.2</version.spark>
         <version.hadoop>3.3.6</version.hadoop>
         <version.hive>3.1.3</version.hive>
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L31-->  

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
         <version.hive>3.1.3</version.hive>
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L31-->  
         <version.awssdk>2.24.5</version.awssdk>
+        <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L44-->  
+        <version.googlelibraries>26.28.0</version.googlelibraries>
         <version.testcontainers>1.19.3</version.testcontainers>
         <!-- Debezium -->
         <version.debezium>2.5.2.Final</version.debezium>
@@ -86,7 +88,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <!-- gcp -->
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>libraries-bom</artifactId>
+                <version>${version.googlelibraries}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- MySQL JDBC Driver, Binlog reader, Geometry support -->
             <dependency>
                 <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <version.assembly.plugin>3.6.0</version.assembly.plugin>
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L53-->
         <version.jackson>2.14.2</version.jackson>
-        <version.iceberg>1.5.0</version.iceberg>
+        <version.iceberg>1.4.2</version.iceberg>
         <!-- Following two properties defines which version of iceberg-spark-runtime is used -->
         <!-- Example https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-spark-runtime-3.4_2.13/1.4.3 -->
         <version.spark.major>3.4</version.spark.major>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L53-->
         <version.jackson>2.14.2</version.jackson>
         <version.iceberg>1.5.0</version.iceberg>
-        <version.spark>3.3.4</version.spark>
+        <version.spark>3.4.2</version.spark>
         <version.hadoop>3.3.6</version.hadoop>
         <version.hive>3.1.3</version.hive>
         <version.awssdk>2.22.9</version.awssdk>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <version.iceberg>1.4.2</version.iceberg>
         <!-- Following two properties defines which version of iceberg-spark-runtime is used -->
         <!-- Example https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-spark-runtime-3.4_2.13/1.4.3 -->
-        <version.spark.major>3.4</version.spark.major>
+        <version.spark.major>3.5</version.spark.major>
         <version.spark.scala>2.13</version.spark.scala>
         <version.spark>${version.spark.major}.2</version.spark>
         <version.hadoop>3.3.6</version.hadoop>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L53-->
         <version.jackson>2.14.2</version.jackson>
         <version.iceberg>1.5.0</version.iceberg>
+        <!-- Following two properties defines which version of iceberg-spark-runtime is used -->
+        <!-- Example https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-spark-runtime-3.4_2.13/1.4.3 -->
         <version.spark.major>3.4</version.spark.major>
         <version.spark.scala>2.13</version.spark.scala>
         <version.spark>${version.spark.major}.2</version.spark>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <!-- Example https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-spark-runtime-3.4_2.13/1.4.3 -->
         <version.spark.major>3.5</version.spark.major>
         <version.spark.scala>2.13</version.spark.scala>
-        <version.spark>${version.spark.major}.2</version.spark>
+        <version.spark>${version.spark.major}.1</version.spark>
         <version.hadoop>3.3.6</version.hadoop>
         <version.hive>3.1.3</version.hive>
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L31-->  

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <version.awssdk>2.24.5</version.awssdk>
         <!-- Use same version as iceberg https://github.com/apache/iceberg/blob/main/gradle/libs.versions.toml#L44-->  
         <version.googlelibraries>26.28.0</version.googlelibraries>
+        <version.googlebigdataoss>2.2.20</version.googlebigdataoss>
         <version.testcontainers>1.19.3</version.testcontainers>
         <!-- Debezium -->
         <version.debezium>2.5.2.Final</version.debezium>


### PR DESCRIPTION
Align package dependencies to iceberg

- Align Iceberg spark runtime
- Align AWS and GCP dependencies
- And Jackson dependency