### PR TITLE
Add iceberg-hive-metastore jar to distribution

### DIFF
--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -74,6 +74,11 @@
             <version>${version.iceberg}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-hive-metastore</artifactId>
+            <version>${version.iceberg}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-metastore</artifactId>
             <version>${version.hive}</version>


### PR DESCRIPTION
closes https://github.com/memiiso/debezium-server-iceberg/issues/305