### PR TITLE
Revert "Bump io.smallrye:jandex-maven-plugin from 3.1.7 to 3.2.0 (#338)"

### DIFF
--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -350,7 +350,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.1.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
This reverts commit 14e6ea7bec774e58a173ad15437467b3e54df9ea.