### PR TITLE
Upgrade debezium to 3.x and Simplify dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Build with Maven
         run: mvn -B --no-transfer-progress package --file pom.xml -Dsurefire.skipAfterFailureCount=1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 17
+        java-version: 21
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Set env for master(latest) release
         if: github.ref_name == 'master'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM eclipse-temurin:17-jdk as builder
+FROM eclipse-temurin:21-jdk as builder
 RUN apt-get -qq update && apt-get -qq install maven unzip
 COPY . /app
 WORKDIR /app
 RUN mvn clean package -Passembly -Dmaven.test.skip --quiet
 RUN unzip /app/debezium-server-iceberg-dist/target/debezium-server-iceberg-dist*.zip -d appdist
 
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:21-jre
 COPY --from=builder /app/appdist/debezium-server-iceberg/ /app/
 
 WORKDIR /app

--- a/debezium-server-iceberg-dist/pom.xml
+++ b/debezium-server-iceberg-dist/pom.xml
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${version.quarkus}</version>
+                <version>${quarkus.version.runtime}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -395,7 +395,11 @@
                         <maven.home>${maven.home}</maven.home>
                         <maven.settings>${session.request.userSettingsFile.path}</maven.settings>
                     </systemProperties>
-
+                    <systemPropertyVariables>
+                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -348,7 +348,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${version.quarkus}</version>
+                <version>${quarkus.version.runtime}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -269,7 +269,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
-            <version>${version.quarkus}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -277,11 +276,6 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
             <version>42.7.4</version>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.minio</groupId>

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerMangodbTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerMangodbTest.java
@@ -11,7 +11,7 @@ package io.debezium.server.iceberg;
 import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourceMangoDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -29,8 +29,8 @@ import java.util.Map;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourceMangoDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourceMangoDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerMangodbTest.TestProfile.class)
 public class IcebergChangeConsumerMangodbTest extends BaseSparkTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerMysqlTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerMysqlTest.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Lists;
 import io.debezium.server.iceberg.testresources.BaseTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourceMysqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -29,8 +29,8 @@ import java.util.Map;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourceMysqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourceMysqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerMysqlTest.TestProfile.class)
 public class IcebergChangeConsumerMysqlTest extends BaseTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerMysqlTestUnwrapped.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerMysqlTestUnwrapped.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Lists;
 import io.debezium.server.iceberg.testresources.BaseTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourceMysqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -32,8 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourceMysqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourceMysqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerMysqlTestUnwrapped.TestProfile.class)
 public class IcebergChangeConsumerMysqlTestUnwrapped extends BaseTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTest.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Lists;
 import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -42,8 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourcePostgresqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerTest.TestProfile.class)
 public class IcebergChangeConsumerTest extends BaseSparkTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTestUnwraapped.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTestUnwraapped.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Lists;
 import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -36,8 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourcePostgresqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerTestUnwraapped.TestProfile.class)
 public class IcebergChangeConsumerTestUnwraapped extends BaseSparkTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerUpsertDeleteDeletesTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerUpsertDeleteDeletesTest.java
@@ -11,7 +11,7 @@ package io.debezium.server.iceberg;
 import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.TestUtil;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -31,7 +31,7 @@ import java.util.Map;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerUpsertDeleteDeletesTest.TestProfile.class)
 public class IcebergChangeConsumerUpsertDeleteDeletesTest extends BaseSparkTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerUpsertTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerUpsertTest.java
@@ -12,7 +12,7 @@ import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
 import io.debezium.server.iceberg.testresources.TestUtil;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -35,8 +35,8 @@ import java.util.Map;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourcePostgresqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerUpsertTest.TestProfile.class)
 public class IcebergChangeConsumerUpsertTest extends BaseSparkTest {
 

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergEventsChangeConsumerTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergEventsChangeConsumerTest.java
@@ -11,7 +11,7 @@ package io.debezium.server.iceberg;
 import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourceMysqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -31,8 +31,8 @@ import java.util.Map;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourceMysqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourceMysqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergEventsChangeConsumerTest.TestProfile.class)
 public class IcebergEventsChangeConsumerTest extends BaseSparkTest {
   @ConfigProperty(name = "debezium.sink.type")

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/batchsizewait/MaxBatchSizeWaitTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/batchsizewait/MaxBatchSizeWaitTest.java
@@ -11,7 +11,7 @@ package io.debezium.server.iceberg.batchsizewait;
 import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -28,8 +28,8 @@ import java.util.Map;
 
 @QuarkusTest
 @TestProfile(MaxBatchSizeWaitTest.TestProfile.class)
-@WithTestResource(value = SourcePostgresqlDB.class)
-@WithTestResource(value = S3Minio.class)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
 class MaxBatchSizeWaitTest extends BaseSparkTest {
   @Inject
   MaxBatchSizeWait waitBatchSize;

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/history/IcebergSchemaHistoryTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/history/IcebergSchemaHistoryTest.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Lists;
 import io.debezium.server.iceberg.testresources.BaseTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourceMysqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
@@ -32,8 +32,8 @@ import java.util.Map;
  */
 @QuarkusTest
 @Disabled // @TODO remove spark with antlr4 version
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourceMysqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourceMysqlDB.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergSchemaHistoryTest.TestProfile.class)
 public class IcebergSchemaHistoryTest extends BaseTest {
   @Test

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/offset/IcebergOffsetBackingStoreTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/offset/IcebergOffsetBackingStoreTest.java
@@ -11,7 +11,7 @@ package io.debezium.server.iceberg.offset;
 import com.google.common.collect.Lists;
 import io.debezium.server.iceberg.testresources.BaseTest;
 import io.debezium.server.iceberg.testresources.S3Minio;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
@@ -36,7 +36,7 @@ import static io.debezium.server.iceberg.offset.IcebergOffsetBackingStore.toByte
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
 public class IcebergOffsetBackingStoreTest extends BaseTest {
 
   private static final Map<ByteBuffer, ByteBuffer> firstSet = new HashMap<>();

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperatorTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/tableoperator/IcebergTableOperatorTest.java
@@ -15,7 +15,7 @@ import io.debezium.server.iceberg.testresources.BaseSparkTest;
 import io.debezium.server.iceberg.testresources.IcebergChangeEventBuilder;
 import io.debezium.server.iceberg.testresources.S3Minio;
 import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
-import io.quarkus.test.common.WithTestResource;
+import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.apache.iceberg.Table;
@@ -39,8 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Ismail Simsek
  */
 @QuarkusTest
-@WithTestResource(value = S3Minio.class)
-@WithTestResource(value = SourcePostgresqlDB.class)
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
 class IcebergTableOperatorTest extends BaseSparkTest {
 
   static String testTable = "inventory.test_table_operator";

--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,22 @@
 
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-build-parent</artifactId>
+        <version>3.0.4.Final</version>
+    </parent>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.debezium</groupId>
     <artifactId>debezium-server-iceberg</artifactId>
-    <name>Debezium Server Parent</name>
+    <name>Debezium Server Iceberg</name>
     <version>${revision}</version>
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.4.0-SNAPSHOT</revision>
+        <!-- NOTE: this is override by release process using CLI argument -->
+        <revision>0.0.1-SNAPSHOT</revision>
+        <!-- Debezium Version! NOTE: keep same as parent.version above! -->
+        <version.debezium>3.0.4.Final</version.debezium>
 
         <!-- Instruct the build to use only UTF-8 encoding for source code -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -39,14 +46,6 @@
         <version.hive>3.1.3</version.hive>
         <version.googlebigdataoss>2.2.20</version.googlebigdataoss>
         <version.testcontainers>1.20.4</version.testcontainers>
-        <!-- Debezium -->
-        <!-- NOTE:Use same version as debezium https://github.com/debezium/debezium/blob/main/pom.xml -->
-        <version.debezium>3.0.4.Final</version.debezium>
-        <!-- NOTE:Use same version as debezium ${quarkus.version.runtime} https://github.com/debezium/debezium/blob/main/pom.xml -->
-        <!-- NOTE:This is only needed for quarkus-maven-plugin Quarkus dependency is defined by Debezium -->
-        <version.quarkus>3.8.5</version.quarkus>
-        <!-- NOTE:Use same version as debezium https://github.com/debezium/debezium/blob/main/debezium-bom/pom.xml -->
-        <version.groovy>4.0.17</version.groovy>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -70,14 +69,6 @@
                 <groupId>org.jboss.slf4j</groupId>
                 <artifactId>slf4j-jboss-logmanager</artifactId>
                 <version>[1.2.0.Final,)</version>
-            </dependency>
-            <!-- Debezium Scripting -->
-            <dependency>
-                <groupId>org.apache.groovy</groupId>
-                <artifactId>groovy-bom</artifactId>
-                <version>${version.groovy}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <!-- Test dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>3.0.4.Final</version>
+        <version>3.0.5.Final</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-server-iceberg</artifactId>
@@ -25,7 +25,7 @@
         <!-- NOTE: this is override by release process using CLI argument -->
         <revision>0.0.1-SNAPSHOT</revision>
         <!-- Debezium Version! NOTE: keep same as parent.version above! -->
-        <version.debezium>3.0.4.Final</version.debezium>
+        <version.debezium>3.0.5.Final</version.debezium>
 
         <!-- Instruct the build to use only UTF-8 encoding for source code -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -64,25 +64,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- log -->
-            <dependency>
-                <groupId>org.jboss.slf4j</groupId>
-                <artifactId>slf4j-jboss-logmanager</artifactId>
-                <version>[1.2.0.Final,)</version>
-            </dependency>
-            <!-- Test dependencies -->
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>4.12.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.squareup.okio</groupId>
-                <artifactId>okio</artifactId>
-                <version>3.9.0</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,67 +41,35 @@
         <version.testcontainers>1.20.4</version.testcontainers>
         <!-- Debezium -->
         <!-- NOTE:Use same version as debezium https://github.com/debezium/debezium/blob/main/pom.xml -->
-        <version.debezium>2.7.4.Final</version.debezium>
-        <version.jackson>2.16.2</version.jackson>
-        <version.mysql.driver>8.0.32</version.mysql.driver>
-        <version.mongo.driver>4.11.5</version.mongo.driver>
+        <version.debezium>3.0.4.Final</version.debezium>
+        <!-- NOTE:Use same version as debezium ${quarkus.version.runtime} https://github.com/debezium/debezium/blob/main/pom.xml -->
+        <!-- NOTE:This is only needed for quarkus-maven-plugin Quarkus dependency is defined by Debezium -->
+        <version.quarkus>3.8.5</version.quarkus>
         <!-- NOTE:Use same version as debezium https://github.com/debezium/debezium/blob/main/debezium-bom/pom.xml -->
         <version.groovy>4.0.17</version.groovy>
-        <!-- Quarkus -->
-        <version.quarkus>3.15.1</version.quarkus>
     </properties>
     <dependencyManagement>
         <dependencies>
+            <!-- debezium server -->
             <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${version.jackson}</version>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-server-bom</artifactId>
+                <version>${version.debezium}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- MySQL JDBC Driver, Binlog reader, Geometry support -->
             <dependency>
-                <groupId>mysql</groupId>
-                <artifactId>mysql-connector-java</artifactId>
-                <version>${version.mysql.driver}</version>
-            </dependency>
-            <!-- Mongo JDBC Driver -->
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-sync</artifactId>
-                <version>${version.mongo.driver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-driver-core</artifactId>
-                <version>${version.mongo.driver}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>bson</artifactId>
-                <version>${version.mongo.driver}</version>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-bom</artifactId>
+                <version>${version.debezium}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- log -->
             <dependency>
                 <groupId>org.jboss.slf4j</groupId>
                 <artifactId>slf4j-jboss-logmanager</artifactId>
                 <version>[1.2.0.Final,)</version>
-            </dependency>
-            <!-- Quarkus -->
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${version.quarkus}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <!-- debezium server -->
-            <dependency>
-                <groupId>io.debezium</groupId>
-                <artifactId>debezium-server</artifactId>
-                <version>${version.debezium}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
             <!-- Debezium Scripting -->
             <dependency>


### PR DESCRIPTION
Resolves #429
Resolves #450

- Upgrade Debezium to 3.0.5.Final
- Set debezium as parent project and let debezium to define Quarkus version. **This downgrades Quarkus version to 3.8.5**
- Remove further custom dependency definitions, let them be inherited from parent project(Debezium)