### PR TITLE
Add support for Iceberg decimals

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/RecordConverter.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/RecordConverter.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -205,6 +207,16 @@ public class RecordConverter {
         return node.floatValue();
       case DOUBLE: // double is represented in 64 bits
         return node.asDouble();
+      case DECIMAL: {
+          BigDecimal decimalVal = null;
+          try {
+              int scale = ((Types.DecimalType) field.type()).scale();
+              decimalVal = new BigDecimal(new BigInteger(node.binaryValue()), scale);
+          } catch (IOException e) {
+              throw new RuntimeException("Failed to convert decimal value to iceberg value, field: " + field.name(), e);
+          }
+          return decimalVal;
+      }
       case BOOLEAN:
         return node.asBoolean();
       case UUID:

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerDecimalTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerDecimalTest.java
@@ -1,0 +1,90 @@
+/*
+ *
+ *  * Copyright memiiso Authors.
+ *  *
+ *  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package io.debezium.server.iceberg;
+
+import com.google.common.collect.Lists;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.server.iceberg.testresources.CatalogJdbc;
+import io.debezium.server.iceberg.testresources.S3Minio;
+import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.debezium.server.iceberg.TestConfigSource.ICEBERG_CATALOG_TABLE_NAMESPACE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration test that verifies basic reading from PostgreSQL database and writing to iceberg destination.
+ *
+ * @author Ismail Simsek
+ */
+@QuarkusTest
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = CatalogJdbc.class, restrictToAnnotatedClass = true)
+@TestProfile(IcebergChangeConsumerDecimalTest.TestProfile.class)
+public class IcebergChangeConsumerDecimalTest extends BaseSparkTest {
+
+  @Test
+  public void testConsumingNumerics() throws Exception {
+    assertEquals(sinkType, "iceberg");
+    String sql = "\n" +
+        "        DROP TABLE IF EXISTS inventory.data_types;\n" +
+        "        CREATE TABLE IF NOT EXISTS inventory.data_types (\n" +
+        "            c_id INTEGER ,\n" +
+        "            c_decimal DECIMAL(18,6)\n" +
+        "          );";
+    SourcePostgresqlDB.runSQL(sql);
+    sql = "INSERT INTO inventory.data_types (c_id, c_decimal) " +
+        "VALUES (1, '1234566.34456'::decimal)";
+    SourcePostgresqlDB.runSQL(sql);
+    Awaitility.await().atMost(Duration.ofSeconds(320)).until(() -> {
+      try {
+        Dataset<Row> df = getTableData("testc.inventory.data_types");
+        df.show(false);
+
+        Assertions.assertEquals(1, df.count());
+        Assertions.assertEquals(1, df.filter("c_id = 1 AND c_decimal = CAST('1234566.344560' AS DECIMAL(18,6))").count(), "c_decimal not matching");
+        return true;
+      } catch (Exception e) {
+        e.printStackTrace();
+        return false;
+      }
+    });
+  }
+
+  public static class TestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> config = new HashMap<>();
+      config.put("debezium.sink.iceberg.destination-regexp", "\\d");
+      config.put("debezium.source.decimal.handling.mode", "precise");
+      return config;
+    }
+  }
+
+}


### PR DESCRIPTION
Hi @ismailsimsek,

Thanks for working on this project! I'm trying to use `debezium-server-iceberg` to write some `NUMERIC`/`DECIMAL` data from postgres to iceberg. Currently depending on the `decimal.handling.mode` setting decimals are written out as doubles, or as strings, or as byte arrays (when `precise` mode is used). Neither of these options seem ideal, and given that Iceberg natively supports decimals I thought it would be nice to be able to stream postgres numerics to iceberg decimals. In this patch I propose a few changes that would allow this.

Thanks!