### PR TITLE
Utilize flatten-maven-plugin to allow debezium-server-iceberg to be used as a maven dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.flattened-pom.xml
 
 deploy.sh
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,31 @@
                     <skipStaging>true</skipStaging>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.7.0</version>
+                <configuration>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
When attempting to use [`io.debezium.debezium-server-iceberg-sink`](https://github.com/memiiso/debezium-server-iceberg/packages/2415952) 

```
ERROR] Failed to execute goal on project tigerlake-sink: Could not collect dependencies for project com.timescale:tigerlake-sink:jar:0.0.1-SNAPSHOT
[ERROR] Failed to read artifact descriptor for io.debezium:debezium-server-iceberg-sink:jar:latest
[ERROR]         Caused by: The following artifacts could not be resolved: io.debezium:debezium-server-iceberg:pom:${revision} (absent): io.debezium:debezium-server-iceberg:pom:${revision} was not found in https://maven.pkg.github.com/memiiso/debezium-server-iceberg during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of github has elapsed or updates are forced
[ERROR] 
[ERROR] -> [Help 1]
```

Using the flatten plugin should allow us to properly depend on the github artifacts. 

- https://maven.apache.org/guides/mini/guide-maven-ci-friendly.html#install-deploy