### PR TITLE
Revert "Bump io.smallrye:jandex-maven-plugin from 3.2.7 to 3.3.0"

### DIFF
--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -334,7 +334,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>


### PR DESCRIPTION
Reverts memiiso/debezium-server-iceberg#540