### PR TITLE
Allow table columns to be excluded from the written iceberg table

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
@@ -6,6 +6,7 @@ import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import org.apache.iceberg.CatalogProperties;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,6 +79,9 @@ public interface IcebergConfig {
   @WithName("debezium.sink.iceberg.allow-field-addition")
   @WithDefault("true")
   boolean allowFieldAddition();
+
+  @WithName("debezium.sink.iceberg.excluded-columns")
+  Optional<List<String>> excludedColumns();
 
   @WithName("debezium.sink.iceberg.io-impl")
   @WithDefault("org.apache.iceberg.io.ResolvingFileIO")

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/converter/JsonSchemaConverter.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/converter/JsonSchemaConverter.java
@@ -12,6 +12,8 @@ import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 public class JsonSchemaConverter implements io.debezium.server.iceberg.converter.SchemaConverter {
@@ -141,8 +143,16 @@ public class JsonSchemaConverter implements io.debezium.server.iceberg.converter
    */
   private IcebergSchemaInfo icebergSchemaFields(JsonNode schemaNode, JsonNode keySchemaNode, IcebergSchemaInfo schemaData) {
     LOGGER.debug("Converting iceberg schema to debezium:{}", schemaNode);
+    List<String> excludedColumns = this.config.iceberg()
+          .excludedColumns()
+          .orElse(Collections.emptyList());
+
     for (JsonNode field : getNodeFieldsArray(schemaNode)) {
       String fieldName = field.get("field").textValue();
+        if(excludedColumns.contains(fieldName)) {
+            continue;
+        }
+
       JsonNode equivalentKeyFieldNode = findNodeFieldByName(fieldName, keySchemaNode);
       debeziumFieldToIcebergField(field, fieldName, schemaData, equivalentKeyFieldNode);
     }

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/converter/StructSchemaConverter.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/converter/StructSchemaConverter.java
@@ -162,8 +162,17 @@ public class StructSchemaConverter implements SchemaConverter {
    */
   private IcebergSchemaInfo icebergSchemaFields(Schema valueSchema, Schema keySchema, IcebergSchemaInfo schemaData) {
     LOGGER.debug("Converting Connect schema fields to Iceberg fields for schema: {}", valueSchema);
+
+    List<String> excludedColumns = this.config.iceberg()
+            .excludedColumns()
+            .orElse(Collections.emptyList());
+
     for (Field field : getSchemaFields(valueSchema)) {
       String fieldName = field.name();
+      if(excludedColumns.contains(fieldName)) {
+        continue;
+      }
+
       debeziumFieldToIcebergField(field, schemaData, equivalentKeyField(keySchema, fieldName));
     }
     return schemaData;

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerExcludedColumnsTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerExcludedColumnsTest.java
@@ -1,0 +1,87 @@
+/*
+ *
+ *  * Copyright memiiso Authors.
+ *  *
+ *  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+
+package io.debezium.server.iceberg;
+
+import io.debezium.server.iceberg.testresources.CatalogJdbc;
+import io.debezium.server.iceberg.testresources.S3Minio;
+import io.debezium.server.iceberg.testresources.SourcePostgresqlDB;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Integration test that verifies columns can be excluded from the written iceberg table
+ *
+ * @author Ismail Simsek
+ */
+@QuarkusTest
+@QuarkusTestResource(value = S3Minio.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = SourcePostgresqlDB.class, restrictToAnnotatedClass = true)
+@QuarkusTestResource(value = CatalogJdbc.class, restrictToAnnotatedClass = true)
+@TestProfile(IcebergChangeConsumerExcludedColumnsTest.TestProfile.class)
+public class IcebergChangeConsumerExcludedColumnsTest extends BaseSparkTest {
+
+  @Test
+  public void testSupportExcludedColumns() throws Exception {
+    String sql =
+            "DROP TABLE IF EXISTS inventory.table_with_excluded_column;\n" +
+            "CREATE TABLE IF NOT EXISTS inventory.table_with_excluded_column (\n" +
+            "    c_id INTEGER ,\n" +
+            "    c_text TEXT ,\n" +
+            "    c_exclude_me TEXT\n" +
+            ");";
+    SourcePostgresqlDB.runSQL(sql);
+    sql = "INSERT INTO inventory.table_with_excluded_column \n" +
+          "(c_id, c_text, c_exclude_me) \n" +
+          "VALUES \n" +
+          "(1, 'one' , 'should_not_write_to_iceberg' ) \n" +
+          ",(1, 'two' , 'should_not_write_to_iceberg' )";
+
+    SourcePostgresqlDB.runSQL(sql);
+    Awaitility.await().atMost(Duration.ofSeconds(320)).until(() -> {
+      try {
+        Dataset<Row> df = getTableData("testc.inventory.table_with_excluded_column");
+        df.show(false);
+        df.schema().printTreeString();
+
+        List<String> columns = Arrays.asList(df.columns());
+
+        Assertions.assertTrue(columns.contains("c_id"));
+        Assertions.assertTrue(columns.contains("c_text"));
+        Assertions.assertFalse(columns.contains("c_exclude_me"));
+        Assertions.assertFalse(columns.contains("__table"));
+        Assertions.assertFalse(columns.contains("__db"));
+        return true;
+      } catch (Exception e) {
+        return false;
+      }
+    });
+  }
+
+  public static class TestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      Map<String, String> config = new HashMap<>();
+      config.put("debezium.sink.iceberg.excluded-columns", "c_exclude_me,__table,__db");
+      return config;
+    }
+  }
+}


### PR DESCRIPTION
 - Some consumers may not want all metadata columns or specific table tables