### PR TITLE
Enforce non temporal(dynamic) precision mode

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/DebeziumConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/DebeziumConfig.java
@@ -21,6 +21,10 @@ public interface DebeziumConfig {
   @WithDefault("isostring")
   TemporalPrecisionMode temporalPrecisionMode();
 
+  @WithName("debezium.source.time.precision.mode.adaptive-allowed")
+  @WithDefault("false")
+  boolean temporalPrecisionModeAdaptiveAllowed();
+
   @WithName("debezium.source.decimal.handling.mode")
   @WithDefault("double")
   RelationalDatabaseConnectorConfig.DecimalHandlingMode decimalHandlingMode();

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/DebeziumConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/DebeziumConfig.java
@@ -116,6 +116,14 @@ public interface DebeziumConfig {
     return this.valueFormat();
   }
 
+  default void validateTemporalPrecisionMode() {
+    if (isAdaptiveTemporalMode()) {
+      if (!temporalPrecisionModeAdaptiveAllowed()) {
+        throw new DebeziumException("Debezium Adaptive Temporal Precision Modes are not supported!  Temporal Precision Mode:" + temporalPrecisionMode() +
+            " to enable it set `debezium.source.time.precision.mode.adaptive-allowed` to true.");
+      }
+    }
+  }
 
   default boolean isEventFlatteningEnabled() {
     if (transformsConfigs() == null || transformsConfigs().isEmpty()) {

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergChangeConsumer.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergChangeConsumer.java
@@ -71,12 +71,7 @@ public class IcebergChangeConsumer implements DebeziumEngine.ChangeConsumer<Embe
 
   @PostConstruct
   void connect() {
-
-    if (config.debezium().isAdaptiveTemporalMode()) {
-      if (!config.debezium().temporalPrecisionModeAdaptiveAllowed()) {
-        throw new DebeziumException("Debezium Adaptive Temporal Precision Modes are not supported!  Temporal Precision Mode:" + config.debezium().temporalPrecisionMode());
-      }
-    }
+    config.debezium().validateTemporalPrecisionMode();
 
     JsonEventConverter.initializeJsonSerde();
     keyValueChangeEventFormat = config.debezium().keyValueChangeEventFormat();

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergChangeConsumer.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergChangeConsumer.java
@@ -71,6 +71,11 @@ public class IcebergChangeConsumer implements DebeziumEngine.ChangeConsumer<Embe
 
   @PostConstruct
   void connect() {
+
+    if (config.debezium().isAdaptiveTemporalMode()) {
+      throw new DebeziumException("Debezium Adaptive Temporal Precision Modes are not supported!  Temporal Precision Mode:" + config.debezium().temporalPrecisionMode());
+    }
+
     JsonEventConverter.initializeJsonSerde();
     keyValueChangeEventFormat = config.debezium().keyValueChangeEventFormat();
     // pass iceberg properties to iceberg and hadoop

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergChangeConsumer.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergChangeConsumer.java
@@ -73,7 +73,9 @@ public class IcebergChangeConsumer implements DebeziumEngine.ChangeConsumer<Embe
   void connect() {
 
     if (config.debezium().isAdaptiveTemporalMode()) {
-      throw new DebeziumException("Debezium Adaptive Temporal Precision Modes are not supported!  Temporal Precision Mode:" + config.debezium().temporalPrecisionMode());
+      if (!config.debezium().temporalPrecisionModeAdaptiveAllowed()) {
+        throw new DebeziumException("Debezium Adaptive Temporal Precision Modes are not supported!  Temporal Precision Mode:" + config.debezium().temporalPrecisionMode());
+      }
     }
 
     JsonEventConverter.initializeJsonSerde();

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTest.java
@@ -119,12 +119,10 @@ public class IcebergChangeConsumerTest extends BaseSparkTest {
         Assertions.assertEquals(1, df.filter("c_id = 2 AND c_decimal = CAST('1234566.34456' AS DOUBLE)").count(), "c_decimal not matching");
         Assertions.assertEquals(1, df.filter("c_id = 2 AND c_numeric = CAST('345672123.452' AS DOUBLE)").count(), "c_numeric not matching");
         // Validate c_timestamp, c_timestamp2, and c_timestamptz casted to date are equal to today
-        if (config.debezium().isConnectKeyValueChangeEventFormat()) {
           // connect mode supports timestamp formats
-          Assertions.assertEquals(1, df.filter("c_id = 2 AND CAST(c_timestamp AS DATE) = CURRENT_DATE()").count(), "c_timestamp not matching");
-          Assertions.assertEquals(1, df.filter("c_id = 2 AND CAST(c_timestamp2 AS DATE) = CURRENT_DATE()").count(), "c_timestamp2 not matching");
-          Assertions.assertEquals(1, df.filter("c_id = 2 AND CAST(c_timestamptz AS DATE) = CURRENT_DATE()").count(), "c_timestamptz not matching");
-        }
+        Assertions.assertEquals(1, df.filter("c_id = 2 AND CAST(c_timestamp AS DATE) = CURRENT_DATE()").count(), "c_timestamp not matching");
+        Assertions.assertEquals(1, df.filter("c_id = 2 AND CAST(c_timestamp2 AS DATE) = CURRENT_DATE()").count(), "c_timestamp2 not matching");
+        Assertions.assertEquals(1, df.filter("c_id = 2 AND CAST(c_timestamptz AS DATE) = CURRENT_DATE()").count(), "c_timestamptz not matching");
         return true;
       } catch (Exception e) {
         e.printStackTrace();

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/TestConfigSource.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/TestConfigSource.java
@@ -38,7 +38,6 @@ public class TestConfigSource implements ConfigSource {
     config.put("debezium.source.database.dbname", "testing-without-source-db");
     config.put("debezium.source.database.user", "testing-without-source-db-user");
     config.put("debezium.source.database.hostname", "testing-without-source-db-hostname");
-    config.put("debezium.source.time.precision.mode", "adaptive");
     // common mysql config
     // "The 'adaptive' time.precision.mode is not supported for this connector"
     config.put("%mysql.debezium.source.time.precision.mode", "connect");

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/testresources/S3Minio.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/testresources/S3Minio.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class S3Minio implements QuarkusTestResourceLifecycleManager {
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(S3Minio.class);
-  static final String DEFAULT_IMAGE = "minio/minio:latest";
+  static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2025-04-08T15-41-24Z";
   public static MinioClient client;
 
   static public final MinIOContainer container = new MinIOContainer(DockerImageName.parse(DEFAULT_IMAGE))


### PR DESCRIPTION
Enforce non adaptive(dynamic) precision mode, only then we can align schema handling between `json` and `connect` event formats