### PR TITLE
feat: reselect unavailable values on delete

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/DebeziumConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/DebeziumConfig.java
@@ -29,6 +29,10 @@ public interface DebeziumConfig {
   @WithDefault("double")
   RelationalDatabaseConnectorConfig.DecimalHandlingMode decimalHandlingMode();
 
+  @WithName("debezium.source.unavailable.value.placeholder")
+  @WithDefault(RelationalDatabaseConnectorConfig.DEFAULT_UNAVAILABLE_VALUE_PLACEHOLDER)
+  String unavailableValuePlaceholder();
+
   // Event format
   @WithName("debezium.format.value")
   @WithDefault("connect")

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
@@ -99,4 +99,8 @@ public interface IcebergConfig {
   @WithDefault("false")
   boolean nestedAsVariant();
 
+  @WithName("debezium.sink.iceberg.reselect-unavailable-values-on-delete")
+  @WithDefault("false")
+  boolean reselectUnavailableValuesOnDelete();
+
 }


### PR DESCRIPTION
This PR adds an option to reselect unavailable values on delete. In case of updates [`ReselectColumnsPostProcessor`](https://debezium.io/documentation/reference/stable/post-processors/reselect-columns.html) do the same thing, but in case of deletes there are no values in the source and so to have fully working soft deletes we need to read unavailable values from the iceberg table.