### PR TITLE
 Add support for table-specific config

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
@@ -5,10 +5,13 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.util.PropertyUtil;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
@@ -17,9 +20,21 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 @ConfigMapping
 public interface IcebergConfig {
   String PROP_PREFIX = "debezium.sink.iceberg";
+  String HADOOP_PROP_PREFIX = "debezium.sink.iceberg.hadoop";
+  String CATALOG_PROP_PREFIX = "debezium.sink.iceberg.catalog";
+  String TABLE_PROP_PREFIX = "debezium.sink.iceberg.table";
 
   @WithName(PROP_PREFIX)
   Map<String, String> icebergConfigs();
+
+  @WithName(TABLE_PROP_PREFIX)
+  Map<String, IcebergTableConfig> tableConfigs();
+
+  @WithName(HADOOP_PROP_PREFIX)
+  Map<String, String> icebergHadoopConfigs();
+
+  @WithName(CATALOG_PROP_PREFIX)
+  Map<String, String> icebergCatalogConfigs();
 
   @WithName("debezium.sink.iceberg.upsert-op-field")
   @WithDefault("__op")

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergEventsChangeConsumer.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergEventsChangeConsumer.java
@@ -113,9 +113,9 @@ public class IcebergEventsChangeConsumer extends BaseChangeConsumer implements D
   @PostConstruct
   void connect() {
     // pass iceberg properties to iceberg and hadoop
-    config.iceberg().icebergConfigs().forEach(this.hadoopConf::set);
+    config.iceberg().icebergHadoopConfigs().forEach(this.hadoopConf::set);
 
-    icebergCatalog = CatalogUtil.buildIcebergCatalog(config.iceberg().catalogName(), config.iceberg().icebergConfigs(), hadoopConf);
+    icebergCatalog = CatalogUtil.buildIcebergCatalog(config.iceberg().catalogName(), config.iceberg().icebergCatalogConfigs(), hadoopConf);
     TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of(config.iceberg().namespace()), TABLE_NAME);
 
     // create table if not exists

--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergTableConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergTableConfig.java
@@ -1,0 +1,7 @@
+package io.debezium.server.iceberg;
+
+import java.util.Map;
+
+public interface IcebergTableConfig {
+    Map<String, String> props();
+}


### PR DESCRIPTION
Currently, the Debezium Iceberg consumer applies global configuration settings across all tables. 
However, different tables may require different handling (e.g., partition fields, branches or use different file formats). Adding support for table-level configuration enhances flexibility and aligns with real-world data lake requirements.
