### PR TITLE
feat: scripting, jmx and metrics configs

### DIFF
--- a/debezium-server-iceberg-dist/src/main/resources/assemblies/server-distribution.xml
+++ b/debezium-server-iceberg-dist/src/main/resources/assemblies/server-distribution.xml
@@ -32,7 +32,31 @@
                 <exclude>org.codehaus.plexus:*:*</exclude>
                 <exclude>log4j:log4j:*</exclude>
                 <exclude>ch.qos.reload4j:reload4j</exclude>
+    	        <exclude>io.debezium:debezium-scripting</exclude>
+                <exclude>io.debezium:debezium-scripting-languages</exclude>
+                <exclude>io.prometheus.jmx:jmx_prometheus_javaagent:*</exclude>
             </excludes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>${project.parent.artifactId}/lib_metrics</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>io.prometheus.jmx:jmx_prometheus_javaagent:*</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>${project.parent.artifactId}/lib_opt</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>io.debezium:debezium-scripting:*</include>
+                <include>io.debezium:debezium-scripting-languages:*</include>
+            </includes>
         </dependencySet>
     </dependencySets>
     <fileSets>

--- a/debezium-server-iceberg-dist/src/main/resources/distro/config/metrics.yml
+++ b/debezium-server-iceberg-dist/src/main/resources/distro/config/metrics.yml
@@ -1,0 +1,62 @@
+startDelaySeconds: 0
+ssl: false
+lowercaseOutputName: false
+lowercaseOutputLabelNames: false
+rules:
+- pattern: "kafka.producer<type=producer-metrics, client-id=([^>]+)><>([^:]+)"
+  name: "kafka_producer_metrics_$2"
+  type: GAUGE
+  labels:
+    client: "$1"
+- pattern: "kafka.producer<type=producer-node-metrics, client-id=([^>]+), node-id=([^>]+)><>([^:]+)"
+  name: "kafka_producer_node_metrics_$3"
+  type: GAUGE
+  labels:
+    client: "$1"
+    node: "$2"
+- pattern: "kafka.producer<type=producer-topic-metrics, client-id=([^>]+), topic=([^>]+)><>([^:]+)"
+  name: "kafka_producer_topic_metrics_$3"
+  type: GAUGE
+  labels:
+    client: "$1"
+    topic: "$2"
+- pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
+  name: "kafka_connect_worker_metrics_$1"
+  type: GAUGE
+- pattern: "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
+  name: "kafka_connect_metrics_$2"
+  type: GAUGE
+  labels:
+    client: "$1"
+- pattern: "debezium.([^:]+)<type=connector-metrics, context=([^,]+), server=([^,]+), key=([^>]+)><>RowsScanned"
+  name: "debezium_metrics_RowsScanned"
+  type: GAUGE
+  labels:
+    plugin: "$1"
+    name: "$3"
+    context: "$2"
+    table: "$4"
+- pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^,]+), database=([^>]+)>([^:]+)"
+  name: "debezium_metrics_$6"
+  type: GAUGE
+  labels:
+    plugin: "$1"
+    name: "$2"
+    task: "$3"
+    context: "$4"
+    database: "$5"
+- pattern: "debezium.([^:]+)<type=connector-metrics, server=([^,]+), task=([^,]+), context=([^>]+)>([^:]+)"
+  name: "debezium_metrics_$5"
+  type: GAUGE
+  labels:
+    plugin: "$1"
+    name: "$2"
+    task: "$3"
+    context: "$4"
+- pattern: "debezium.([^:]+)<type=connector-metrics, context=([^,]+), server=([^>]+)>([^:]+)"
+  name: "debezium_metrics_$4"
+  type: GAUGE
+  labels:
+    plugin: "$1"
+    name: "$3"
+    context: "$2"

--- a/debezium-server-iceberg-dist/src/main/resources/distro/jmx/enable_jmx.sh
+++ b/debezium-server-iceberg-dist/src/main/resources/distro/jmx/enable_jmx.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# To enable JMX functionality, export the JMX_HOST and JMX_PORT environment variables.
+# Modify the jmxremote.access and jmxremote.password files accordingly.
+if [ -n "${JMX_HOST}" -a -n "${JMX_PORT}" ]; then
+     export JAVA_OPTS="-Dcom.sun.management.jmxremote.ssl=false \
+     -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+     -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+     -Dcom.sun.management.jmxremote.local.only=false \
+     -Djava.rmi.server.hostname=${JMX_HOST} \
+     -Dcom.sun.management.jmxremote.verbose=true"
+
+  if [ -f "jmx/jmxremote.access" -a -f "jmx/jmxremote.password" ]; then
+    chmod 600 jmx/jmxremote.password
+    export JAVA_OPTS="${JAVA_OPTS} -Dcom.sun.management.jmxremote.authenticate=true \
+       -Dcom.sun.management.jmxremote.access.file=jmx/jmxremote.access \
+       -Dcom.sun.management.jmxremote.password.file=jmx/jmxremote.password"
+  else
+   export JAVA_OPTS="${JAVA_OPTS} -Dcom.sun.management.jmxremote.authenticate=false"
+  fi
+fi

--- a/debezium-server-iceberg-dist/src/main/resources/distro/jmx/jmxremote.access
+++ b/debezium-server-iceberg-dist/src/main/resources/distro/jmx/jmxremote.access
@@ -1,0 +1,2 @@
+monitor readonly
+admin readwrite

--- a/debezium-server-iceberg-dist/src/main/resources/distro/jmx/jmxremote.password
+++ b/debezium-server-iceberg-dist/src/main/resources/distro/jmx/jmxremote.password
@@ -1,0 +1,2 @@
+admin admin123
+monitor monitor123

--- a/debezium-server-iceberg-dist/src/main/resources/distro/lib_metrics/enable_exporter.sh
+++ b/debezium-server-iceberg-dist/src/main/resources/distro/lib_metrics/enable_exporter.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# To enable Prometheus JMX exporter, set JMX_EXPORTER_PORT environment variable
+
+if [ -n "${JMX_EXPORTER_PORT}" ]; then
+  JMX_EXPORTER_CONFIG=${JMX_EXPORTER_CONFIG:-"config/metrics.yml"}
+  JMX_EXPORTER_AGENT_JAR=$(find lib_metrics -name "jmx_prometheus_javaagent-*.jar")
+  export JAVA_OPTS="-javaagent:${JMX_EXPORTER_AGENT_JAR}=0.0.0.0:${JMX_EXPORTER_PORT}:${JMX_EXPORTER_CONFIG} ${JAVA_OPTS}"
+fi

--- a/debezium-server-iceberg-dist/src/main/resources/distro/run.sh
+++ b/debezium-server-iceberg-dist/src/main/resources/distro/run.sh
@@ -7,11 +7,7 @@
 #  */
 #
 
-if [ -z "$JAVA_HOME" ]; then
-  JAVA_BINARY="java"
-else
-  JAVA_BINARY="$JAVA_HOME/bin/java"
-fi
+LIB_PATH="lib/*"
 
 if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
   PATH_SEP=";"
@@ -19,6 +15,21 @@ else
   PATH_SEP=":"
 fi
 
+if [ -z "$JAVA_HOME" ]; then
+  JAVA_BINARY="java"
+else
+  JAVA_BINARY="$JAVA_HOME/bin/java"
+fi
+
 RUNNER=$(ls debezium-server-*runner.jar)
 
-exec $JAVA_BINARY $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER"$PATH_SEP"config"$PATH_SEP"lib/*"$PATH_SEP"/opt/conf" io.debezium.server.Main
+ENABLE_DEBEZIUM_SCRIPTING=${ENABLE_DEBEZIUM_SCRIPTING:-false}
+if [[ "${ENABLE_DEBEZIUM_SCRIPTING}" == "true" ]]; then
+  LIB_PATH=$LIB_PATH$PATH_SEP"lib_opt/*"
+fi
+
+source ./jmx/enable_jmx.sh
+source ./lib_metrics/enable_exporter.sh
+
+exec "$JAVA_BINARY" $DEBEZIUM_OPTS $JAVA_OPTS -cp \
+    $RUNNER$PATH_SEP$LIB_PATH io.debezium.server.Main


### PR DESCRIPTION
The PR enhances compatibility with debezium server and operator:
- disable scripting by default (can be enabled with ENABLE_DEBEZIUM_SCRIPTING)
- support JMX_HOST and JMX_PORT env vars
- support JMX_EXPORTER_PORT env var

Related:
- https://github.com/debezium/debezium-server/pull/97