### PR TITLE
fix: update permissions in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ COPY . /app
 WORKDIR /app
 RUN mvn clean package -Passembly -Dmaven.test.skip --quiet -Drevision=${RELEASE_VERSION}
 RUN unzip /app/debezium-server-iceberg-dist/target/debezium-server-iceberg-dist*.zip -d appdist
+RUN mkdir /app/appdist/debezium-server-iceberg/data && \
+    chown -R 185 /app/appdist/debezium-server-iceberg && \
+    chmod -R g+w,o+w /app/appdist/debezium-server-iceberg
 
 # Stage 2: Final image
 FROM registry.access.redhat.com/ubi8/openjdk-21


### PR DESCRIPTION
Create /debezium/data directory and make permissions the same as in the debezium server images.

Without it container can't write offsets and schemahistory to /debezium/data volume and therefore can't start.

https://github.com/debezium/container-images/blob/v3.3.1.Final/server/3.3/Dockerfile#L27-L49