### PR TITLE
Add partition spec support for auto-created Iceberg tables

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/IcebergConfig.java
@@ -99,4 +99,7 @@ public interface IcebergConfig {
   @WithDefault("false")
   boolean nestedAsVariant();
 
+  @WithName("debezium.sink.iceberg.partition-spec")
+  Optional<String> partitionSpec();
+
 }


### PR DESCRIPTION
This change adds support for automatic table partitioning when Debezium auto-creates Iceberg tables, eliminating the need for manual table pre-creation via external tools like Trino.

Changes:
- Added `debezium.sink.iceberg.partition-spec` configuration option
- Implemented partition spec string parser supporting common transforms:
  * Temporal: day(), hour(), month(), year()
  * Hash-based: bucket(column, N)
  * String-based: truncate(column, width)
  * Identity: identity(column)
- Added new createIcebergTable() overload accepting PartitionSpec
- Updated IcebergChangeConsumer to parse and apply partition specs

Benefits:
- Enables clean partitioned layout from day 1 (no mixed layout)
- Improves query performance through partition pruning
- Reduces storage costs via efficient data management
- Supports TTL operations on partitioned tables

Configuration Example:
debezium.sink.iceberg.partition-spec=day(__source_ts_ms)

Multi-column partitioning also supported:
debezium.sink.iceberg.partition-spec=day(__source_ts_ms),bucket(id,16)

Addresses the common use case where users need partitioned tables but want to avoid the overhead of pre-creating tables manually before starting CDC pipelines.