### PR TITLE
fix: handle missing __op field in snapshot events during deduplication

### DIFF
--- a/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/converter/StructEventConverter.java
+++ b/debezium-server-iceberg-sink/src/main/java/io/debezium/server/iceberg/converter/StructEventConverter.java
@@ -129,6 +129,12 @@ public class StructEventConverter extends AbstractEventConverter implements Even
           "Value is null, cannot extract '" + config.iceberg().cdcOpField() + "'");
     }
 
+    // Snapshot events don't pass through the unwrap transform, so __op field
+    // may not exist in the schema. Check schema first to avoid DataException.
+    if (value.schema().field(config.iceberg().cdcOpField()) == null) {
+      return Operation.READ;
+    }
+
     Object opValue = value.get(config.iceberg().cdcOpField());
     if (opValue == null) {
       // Defaulting to 'c' (create/insert) if op field is null, adjust as needed

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/converter/StructEventConverterTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/converter/StructEventConverterTest.java
@@ -1,5 +1,6 @@
 package io.debezium.server.iceberg.converter;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.types.Types;
@@ -45,6 +47,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -582,5 +587,71 @@ class StructEventConverterTest {
     assertNotNull(sortOrder, "Sort order should not be null");
     assertEquals(
         2, sortOrder.fields().size(), "Sort order should have 2 fields (id and tenant_db)");
+  }
+
+  /**
+   * Scenarios for {@link #testCdcOpValue}:
+   *
+   * <ul>
+   *   <li>{@code missing} — value schema does NOT declare an {@code __op} field (e.g. snapshot rows
+   *       that have already been unwrapped, or sources that never produce a Debezium envelope).
+   *       Before the fix this threw a Kafka Connect {@code DataException}; the fix returns {@code
+   *       READ}.
+   *   <li>{@code null-value} — schema declares {@code __op} but the value is {@code null}.
+   *       Pre-existing behavior: defaults to {@code INSERT} with a warning log. Included here to
+   *       guarantee the fix does not change this path.
+   *   <li>{@code c}, {@code i}, {@code u}, {@code d}, {@code r} — schema declares {@code __op} and
+   *       the value is one of the standard Debezium op codes. Standard mapping (regression check).
+   * </ul>
+   */
+  static Stream<Arguments> cdcOpValueScenarios() {
+    return Stream.of(
+        // schemaHasOpField, opValue, expected
+        Arguments.of(false, null, Operation.READ), // missing — the fix
+        Arguments.of(true, null, Operation.INSERT), // present, null -> default INSERT
+        Arguments.of(true, "c", Operation.INSERT),
+        Arguments.of(true, "i", Operation.INSERT),
+        Arguments.of(true, "u", Operation.UPDATE),
+        Arguments.of(true, "d", Operation.DELETE),
+        Arguments.of(true, "r", Operation.READ));
+  }
+
+  @ParameterizedTest(name = "schemaHasOpField={0}, opValue={1} -> {2}")
+  @MethodSource("cdcOpValueScenarios")
+  void testCdcOpValue(boolean schemaHasOpField, String opValue, Operation expected) {
+    SchemaBuilder builder =
+        SchemaBuilder.struct()
+            .name("CdcOpValueScenarioValue")
+            .field("id", Schema.INT32_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA);
+    if (schemaHasOpField) {
+      builder.field(CDC_OP_FIELD, Schema.OPTIONAL_STRING_SCHEMA);
+    }
+    org.apache.kafka.connect.data.Schema valueSchema = builder.build();
+
+    Struct valueStruct = new Struct(valueSchema).put("id", TEST_INT).put("name", TEST_STRING);
+    if (schemaHasOpField && opValue != null) {
+      valueStruct.put(CDC_OP_FIELD, opValue);
+    }
+
+    EmbeddedEngineChangeEvent event = createMockChangeEvent(createTestKeyStruct(), valueStruct);
+    StructEventConverter converter = new StructEventConverter(event, config);
+
+    Operation actual =
+        assertDoesNotThrow(
+            converter::cdcOpValue,
+            "cdcOpValue() must not throw for schemaHasOpField="
+                + schemaHasOpField
+                + ", opValue="
+                + opValue);
+    assertEquals(
+        expected,
+        actual,
+        "cdcOpValue() must return "
+            + expected
+            + " for schemaHasOpField="
+            + schemaHasOpField
+            + ", opValue="
+            + opValue);
   }
 }


### PR DESCRIPTION
## Problem

When Debezium emits snapshot events that haven't been processed by the
`unwrap` transform, the `__op` metadata field is not present in the
event schema. `StructEventConverter.cdcOpValue()` then throws a
`DataException` when trying to read the field, and the dedup pipeline
in `IcebergTableOperator.deduplicateBatch()` fails the whole batch.

This affects every snapshot event source that does not pre-flatten
records (e.g. raw `SourceRecord` flow, custom converter pipelines,
PostgreSQL initial snapshot via `ConverterBuilder.toFormat()` raw mode).

## Fix

Check the value schema for the `__op` field before reading it. If the
field is not declared in the schema, default to `Operation.READ`,
which is the correct semantic for snapshot events where the operation
type is implicit.

## Scope

Single-file change in `StructEventConverter`. No interface/API changes,
no behavioral changes outside the missing-field path.

## Note on previous version

This PR previously also included a `BaseDeltaTaskWriter` change that
treated `READ` as a direct INSERT (skipping the equality delete) to
optimize snapshot writes. That change has been reverted: it would
produce duplicate rows in mixed CDC + incremental-snapshot scenarios
where a `READ` event arrives for a key already present in the table.
The "skip equality delete" optimization is more correctly handled at
the writer-selection layer when the consumer knows it is in a pure
snapshot phase, and will be revisited as part of #693.