### PR TITLE
chore: upgrade Apache Iceberg version to 1.11.0

### DIFF
--- a/debezium-server-iceberg-sink/pom.xml
+++ b/debezium-server-iceberg-sink/pom.xml
@@ -436,6 +436,8 @@
                     </argLine>
                     <environmentVariables>
                         <SPARK_USER>test</SPARK_USER>
+                        <PYSPARK_PYTHON>/nonexistent/python</PYSPARK_PYTHON>
+                        <PYSPARK_DRIVER_PYTHON>/nonexistent/python</PYSPARK_DRIVER_PYTHON>
                     </environmentVariables>
                     <systemPropertyVariables>
                         <maven.settings>${session.request.userSettingsFile.path}</maven.settings>

--- a/examples/nessie/config/application.properties
+++ b/examples/nessie/config/application.properties
@@ -7,7 +7,7 @@ debezium.sink.iceberg.upsert-keep-deletes=true
 debezium.sink.iceberg.write.format.default=parquet
 # S3 config using Nessie catalog And S3FileIO
 debezium.sink.iceberg.type=nessie
-#debezium.sink.iceberg.catalog-impl=org.apache.iceberg.nessie.NessieCatalog
+debezium.sink.iceberg.catalog-impl=org.apache.iceberg.nessie.NessieCatalog
 debezium.sink.iceberg.uri=http://nessie:19120/api/v2
 debezium.sink.iceberg.ref=main
 debezium.sink.iceberg.warehouse=s3://warehouse

--- a/examples/nessie/docker-compose.yaml
+++ b/examples/nessie/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - ./config/application.properties:/debezium/config/application.properties
     command: >
       bash -c "
-      mvn dependency:copy -Dartifact=org.apache.iceberg:iceberg-nessie:1.10.0:jar -DoutputDirectory=/debezium/lib/ \ 
+      mvn dependency:copy -Dartifact=org.apache.iceberg:iceberg-nessie:1.11.0:jar -DoutputDirectory=/debezium/lib/ \ 
       && mvn dependency:copy -Dartifact=org.projectnessie.nessie:nessie-client:0.104.5:jar -DoutputDirectory=/debezium/lib/ \ 
       && mvn dependency:copy -Dartifact=org.projectnessie.nessie:nessie-model:0.104.5:jar -DoutputDirectory=/debezium/lib/ \ 
       && /debezium/run.sh

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <skipITs>true</skipITs>
 
         <!-- Iceberg -->
-        <version.iceberg>1.10.2</version.iceberg>
+        <version.iceberg>1.11.0</version.iceberg>
         <!-- Following two properties defines which version of iceberg-spark-runtime is used -->
         <!-- Example https://mvnrepository.com/artifact/org.apache.iceberg/iceberg-spark-runtime-3.4_2.13/1.4.3 -->
         <version.spark.major>4.0</version.spark.major>


### PR DESCRIPTION
- Upgraded `version.iceberg` to `1.11.0` in the parent `pom.xml`.
- Updated `iceberg-nessie` jar version to `1.11.0` in Nessie example docker-compose.yaml.
- Uncommented the NessieCatalog implementation configuration in Nessie example properties.
- Set PySpark test environment variables to avoid PySpark checking local python binaries.