### PR TITLE
fix: remove test table drops that race with the running Debezium engine

### DIFF
--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerDecimalTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerDecimalTest.java
@@ -24,7 +24,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,17 +38,6 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(value = CatalogNessie.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerDecimalTest.TestProfile.class)
 public class IcebergChangeConsumerDecimalTest extends BaseSparkTest {
-
-  @BeforeAll
-  public static void setup() {
-    if (spark != null) {
-      try {
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_data_types");
-      } catch (Exception e) {
-        LOGGER.warn("Failed to drop tables in setup: {}", e.getMessage());
-      }
-    }
-  }
 
   @Test
   public void testConsumingNumerics() throws Exception {

--- a/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTest.java
+++ b/debezium-server-iceberg-sink/src/test/java/io/debezium/server/iceberg/IcebergChangeConsumerTest.java
@@ -37,7 +37,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataTypes;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,26 +51,6 @@ import org.junit.jupiter.api.Test;
 @QuarkusTestResource(value = CatalogNessie.class, restrictToAnnotatedClass = true)
 @TestProfile(IcebergChangeConsumerTest.TestProfile.class)
 public class IcebergChangeConsumerTest extends BaseSparkTest {
-
-  @BeforeAll
-  public static void setup() {
-    if (spark != null) {
-      try {
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_customers");
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_geom");
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_products");
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_orders");
-        spark.sql(
-            "DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_products_on_hand");
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_data_types");
-        spark.sql("DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_array_data");
-        spark.sql(
-            "DROP TABLE IF EXISTS debeziumevents.debeziumcdc_testc_inventory_data_type_changes");
-      } catch (Exception e) {
-        LOGGER.warn("Failed to drop tables in setup: {}", e.getMessage());
-      }
-    }
-  }
 
   @Test
   public void testConsumingVariousDataTypes() throws Exception {


### PR DESCRIPTION
## Summary

Removes the `@BeforeAll` blocks in `IcebergChangeConsumerTest` and
`IcebergChangeConsumerDecimalTest` that drop destination Iceberg tables.
They race with the already-running Debezium engine and break the build.

## Root cause

`@QuarkusTest` starts the Debezium engine *before* JUnit invokes the test
class's `@BeforeAll` methods. The engine is therefore already snapshotting
Postgres and creating destination tables while `setup()` drops them.

The reported failures are six `ConditionTimeoutException`s, but those are a
symptom. The real error is a suppressed exception on the first test:

    Caused by: org.apache.iceberg.exceptions.NoSuchTableException:
        Table does not exist: debeziumevents.debeziumcdc_testc_inventory_products_on_hand
    Caused by: org.projectnessie.error.NessieReferenceConflictException:
        Key 'debeziumevents.debeziumcdc_testc_inventory_products_on_hand' does not exist.

The log timeline shows the collision in a 4-second window: Spark starts at
`20:32:55`, the engine creates `products_on_hand` at `20:32:59.226`, and its
next commit fails at `20:32:59.569` because the table was concurrently
dropped. Engine failure is fatal in Debezium, so no data lands and every
data-dependent test waits out its Awaitility timeout — roughly 21 minutes
inside a single class, which is most of the job's 39-minute runtime.

The drops were never useful. `CatalogNessie` is a non-static field registered
with `restrictToAnnotatedClass = true`, so each test class gets a fresh Nessie
container with an empty catalog and the tables can never pre-exist. The only
case where `DROP TABLE IF EXISTS` does anything is the one that breaks the
build.

Both blocks were introduced together in #713. The decimal test passes today
but carries the identical race, so it is fixed here too.

## Test plan

- [x] `IcebergChangeConsumerTest` passes all 8 tests locally
      (`Tests run: 8, Failures: 0, Errors: 0`), down from 6 errors
- [x] Class runtime drops from 1266s to 67s, confirming the timeouts were
      spent waiting on an engine that had already died
- [x] `Build Java Project` go green on CI

Fixes the failure in [run 30218696823](https://github.com/memiiso/debezium-server-iceberg/actions/runs/30218696823/job/89837204395),
which reproduced identically across the four most recent `Create Release` runs.