### PR TITLE
fix(github-actions): disable attestations so released images stay pullable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,20 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
+          # Push a plain single-arch manifest, not an OCI image index.
+          #
+          # With attestations enabled (the default once a buildx builder is set up), the push
+          # produces an index whose children are UNTAGGED: the linux/amd64 image plus an
+          # unknown/unknown attestation manifest. The "Delete Untagged Docker Images" step below
+          # then deletes every untagged version, including those children, leaving the release tag
+          # pointing at an index whose members no longer exist. The tag still resolves, so the
+          # breakage is invisible in the UI, but any `docker pull` fails with
+          # "failed to copy: httpReadSeeker: failed open: content at ... not found".
+          #
+          # This restores the manifest shape of pre-buildx releases such as 1.0.0.Final, which are
+          # still pullable today, while keeping the GHA build cache above.
+          provenance: false
+          sbom: false
           build-args: |
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}
           tags: ghcr.io/${{ github.repository_owner }}/debezium-server-iceberg:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
## Every release built since buildx was added cannot be pulled

`1.1.0.Final` and `latest` both resolve as tags, but any pull fails:

```text
failed to pull and unpack image "ghcr.io/memiiso/debezium-server-iceberg:1.1.0.Final":
failed to copy: httpReadSeeker: failed open: content at
https://ghcr.io/v2/memiiso/debezium-server-iceberg/manifests/sha256:15e93cc5... not found
```

The last usable release is **1.0.0.Final**, which ships Debezium 3.3.1.

## Cause

`docker/build-push-action` generates provenance/SBOM attestations by default once a buildx builder is set up. That makes the push produce an **OCI image index** whose children are **untagged**: the `linux/amd64` image, plus an `unknown/unknown` attestation manifest.

The `Delete Untagged Docker Images` step at the end of the same job then deletes *every* untagged version, including those children.

The release tag survives, still pointing at the index, so nothing looks wrong in the Packages UI. The failure only appears on pull, which is why this has gone unreported.

Buildx was introduced in 05f01859 for `cache-to: type=gha`; the attestations came along as a side effect, and the pre-existing cleanup step turned them into deleted layers.

## Verified against the registry (2026-07-31)

```text
1.1.0.Final  ->  application/vnd.oci.image.index.v1+json
    child sha256:15e93cc5..  linux/amd64                                        HTTP 404
    child sha256:b041c267..  unknown/unknown  (vnd.docker.reference.type=
                                               attestation-manifest)            HTTP 404

latest       ->  application/vnd.oci.image.index.v1+json
    child sha256:35299cb9..  linux/amd64                                        HTTP 404

1.0.0.Final  ->  application/vnd.docker.distribution.manifest.v2+json           pulls fine
```

The `attestation-manifest` annotation on the second child is buildx's own marker, so the index provably came from attestation generation. And `1.0.0.Final` predates buildx, pushes a plain manifest with no untagged children, and still works - which pins the regression precisely.

## The fix

`provenance: false` + `sbom: false` restores the single-manifest shape of pre-buildx releases, while keeping the GHA build cache that buildx was added for. One step, two lines (plus a comment explaining why, so the cleanup step's interaction is not re-broken later).

## Worth considering separately

If you ever want **multi-arch** releases (`platforms: linux/amd64,linux/arm64`), an image index with untagged children becomes unavoidable, and `Delete Untagged Docker Images` would break those releases the same way. At that point the cleanup step needs to be scoped to genuinely orphaned versions, or dropped. I have deliberately left that out of this PR to keep it to the regression fix, but I am happy to follow up if you would like it handled.

## Context

We hit this deploying the sink on Kubernetes: ArgoCD synced `1.1.0.Final`, the pod sat in `ImagePullBackOff`, and our Postgres replication slot died while nothing was consuming it. We are currently building the image from source at a pinned commit as a workaround, which we would happily drop once releases are pullable again.

Thanks for the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)